### PR TITLE
feat: add debug functions for backing up and restoring data

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
             ]
         }
     },
+    "engines": {
+        "node": ">=12.0.0 <14"
+    },
     "dependencies": {
         "@suen/electron-updater": "git+https://github.com/sunzongzheng/electron-updater.git",
         "@suen/music-api": "git+https://github.com/sunzongzheng/musicApi.git",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         "css-loader": "^0.28.4",
         "del": "^3.0.0",
         "devtron": "^1.4.0",
-        "electron": "^5.0.5",
+        "electron": "^6.1.12",
         "electron-builder": "22.9.1",
         "electron-devtools-installer": "^2.2.4",
         "extract-text-webpack-plugin": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
         "@suen/music-api": "git+https://github.com/sunzongzheng/musicApi.git",
         "axios": "^0.21.1",
         "bufferutil": "^4.0.0",
+        "compare-versions": "^3.6.0",
         "dayjs": "^1.8.36",
         "electron-dl": "^3.0.2",
         "electron-localshortcut": "^3.1.0",

--- a/src/renderer/view/setting/components/debug.vue
+++ b/src/renderer/view/setting/components/debug.vue
@@ -21,10 +21,17 @@
 </template>
 <script>
 import menuItem from './menu-item.vue'
+import { remote } from 'electron'
+import compareVersions from 'compare-versions'
 
 export default {
     components: {
         menuItem,
+    },
+    data() {
+        return {
+            RESTORE_SUPPORT_VERSION_FROM: '1.3.1',
+        }
     },
     methods: {
         openConsole() {
@@ -33,10 +40,14 @@ export default {
             })
         },
         backup() {
-            const data = new Blob([JSON.stringify(localStorage, null, 2)], {
+            const backupObject = {
+                version: remote.app.getVersion(),
+                data: localStorage,
+            }
+            const jsonFile = new Blob([JSON.stringify(backupObject, null, 2)], {
                 type: 'application/json',
             })
-            const url = URL.createObjectURL(data)
+            const url = URL.createObjectURL(jsonFile)
             const aElement = document.createElement('a')
             aElement.href = url
             aElement.download = 'backup.json'
@@ -47,6 +58,7 @@ export default {
         },
         readSingleFile(changeEvent) {
             const file = changeEvent.target.files[0]
+            const thisComponent = this
             if (file) {
                 const reader = new FileReader()
                 reader.onload = function(loadEvent) {
@@ -55,11 +67,30 @@ export default {
                      */
                     const contents = loadEvent.target.result
                     try {
-                        const restoreJson = JSON.parse(contents)
-                        for (const key in restoreJson) {
-                            localStorage.setItem(key, restoreJson[key])
+                        const backupObject = JSON.parse(contents)
+
+                        // Check if the version is not correct
+                        if (
+                            !backupObject.version || // version field not exists
+                            compareVersions(
+                                backupObject.version,
+                                thisComponent.RESTORE_SUPPORT_VERSION_FROM
+                            ) < 0 || // version is less than RESTORE_SUPPORT_VERSION_FROM
+                            compareVersions(
+                                backupObject.version,
+                                remote.app.getVersion()
+                            ) > 0 // version is greater than current version
+                        ) {
+                            throw new Error(`不支持导入这个版本的数据！`)
+                        } // TODO support convert old version
+                        if (typeof backupObject.data === 'object') {
+                            for (const key in backupObject) {
+                                localStorage.setItem(key, backupObject[key])
+                            }
+                            alert('导入成功！请重启应用。')
+                        } else {
+                            alert('数据格式错误！')
                         }
-                        alert('导入成功！请重启应用。')
                     } catch (error) {
                         alert(error)
                     }

--- a/src/renderer/view/setting/components/debug.vue
+++ b/src/renderer/view/setting/components/debug.vue
@@ -1,27 +1,79 @@
 <template>
     <menu-item title="Debug">
-        <el-button size="small" :class="s.btn" @click="openConsole">打开控制台</el-button>
+        <el-button size="small" :class="s.btn" @click="openConsole"
+            >打开控制台</el-button
+        >
+        <el-button size="small" :class="s.btn" @click="backup"
+            >备份数据</el-button
+        >
+        <el-button size="small" :class="s.btn" @click="restore">
+            导入数据
+            <input
+                id="input-restore"
+                accept=".json,application/json"
+                multiple="false"
+                v-show="false"
+                @change="readSingleFile"
+                type="file"
+            />
+        </el-button>
     </menu-item>
 </template>
 <script>
-    import menuItem from './menu-item.vue'
+import menuItem from './menu-item.vue'
 
-    export default {
-        components: {
-            menuItem
+export default {
+    components: {
+        menuItem,
+    },
+    methods: {
+        openConsole() {
+            this.$mainWindow.webContents.openDevTools({
+                detach: true,
+            })
         },
-        methods: {
-            openConsole() {
-                this.$mainWindow.webContents.openDevTools({
-                    detach: true
-                })
+        backup() {
+            const data = new Blob([JSON.stringify(localStorage, null, 2)], {
+                type: 'application/json',
+            })
+            const url = URL.createObjectURL(data)
+            const aElement = document.createElement('a')
+            aElement.href = url
+            aElement.download = 'backup.json'
+            aElement.click()
+        },
+        restore() {
+            document.getElementById('input-restore').click()
+        },
+        readSingleFile(changeEvent) {
+            const file = changeEvent.target.files[0]
+            if (file) {
+                const reader = new FileReader()
+                reader.onload = function(loadEvent) {
+                    /**
+                     * @type {string}
+                     */
+                    const contents = loadEvent.target.result
+                    try {
+                        const restoreJson = JSON.parse(contents)
+                        for (const key in restoreJson) {
+                            localStorage.setItem(key, restoreJson[key])
+                        }
+                        alert('导入成功！请重启应用。')
+                    } catch (error) {
+                        alert(error)
+                    }
+                }
+                reader.readAsText(file)
+                changeEvent.currentTarget.value = '' // Clean value. Support opening same file in the next time.
             }
-        }
-    }
+        },
+    },
+}
 </script>
 <style lang="scss" module="s">
-    .btn {
-        height: 22px;
-        padding: 0 24px;
-    }
+.btn {
+    height: 22px;
+    padding: 0 24px;
+}
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2160,6 +2160,11 @@ commondir@^1.0.1:
   resolved "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
+compare-versions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+
 component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3097,10 +3097,10 @@ electron-to-chromium@^1.3.150:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.158.tgz#5e16909dcfd25ab7cd1665114ee381083a3ee858"
   integrity sha512-wJsJaWsViNQ129XPGmyO5gGs1jPMHr9vffjHAhUje1xZbEzQcqbENdvfyRD9q8UF0TgFQFCCUbaIpJarFbvsIg==
 
-electron@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.npmjs.org/electron/-/electron-5.0.5.tgz#2d04499064d3f6c89c4642e47cfe9ea151d794eb"
-  integrity sha512-GzVQhImBX3rSCFPyJ1u1KbxquoidAHzGeCH2FTs3lzAh1H8m4vd7xh6CNC111mT/I8pxFk5D8s3atJlJQLPAeg==
+electron@^6.1.12:
+  version "6.1.12"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-6.1.12.tgz#a7aee6dfa75b57f32b3645ef8e14dcef6d5f31a9"
+  integrity sha512-RUPM8xJfTcm53V9EKMBhvpLu1+CQkmuvWDmVCypR5XbUG1OOrOLiKl0CqUZ9+tEDuOmC+DmzmJP2MZXScBU5IA==
   dependencies:
     "@types/node" "^10.12.18"
     electron-download "^4.1.0"


### PR DESCRIPTION
为了调试的时候方便备份和恢复数据，所以在设置界面的Debug区域添加了备份和导入数据的功能。

另外不连接player-be的时候也可以用这个方法来备份和迁移数据。

目前看核心配置信息和歌单完整信息都在localStorage里，所以就只备份了这块；
部分登录信息在Cookies中，处于实用性和安全方面考虑暂未包含这部分的备份。

导入数据的功能不会删除现有数据，仅会覆盖备份文件中提供的字段。